### PR TITLE
Switch the docker image to also use the conda workarounds

### DIFF
--- a/clone_and_start_server.sh
+++ b/clone_and_start_server.sh
@@ -10,7 +10,7 @@ git fetch origin $SERVER_BRANCH
 git checkout -f $SERVER_BRANCH
 
 echo "About to start conda update, this may take some time..."
-conda env update --name emission --file setup/environment36.yml
+source setup/setup.sh
 conda clean -t
 conda clean -p
 

--- a/examples/em-server/README.md
+++ b/examples/em-server/README.md
@@ -18,7 +18,7 @@ The server is started on port 8080.
 Modify the repo and branch if needed. The current code will be checked out to
 the container, and will be removed when the container is removed.
 
-### `docker-compose.dev.livereload.yml: deploy code for editing
+### `docker-compose.dev.livereload.yml`: deploy code for editing
 
 - The code will be mounted to a directory on your host
 - Edit the code on the host for auto-reload


### PR DESCRIPTION
By using `source/setup.sh` instead of using conda directly.
Corresponds to https://github.com/e-mission/e-mission-docs/issues/511