### PR TITLE
Simple fix/hack to support a limited set of indices

### DIFF
--- a/examples/em-server-multi-tier-cronjob/analysis/start_cron.sh
+++ b/examples/em-server-multi-tier-cronjob/analysis/start_cron.sh
@@ -1,5 +1,11 @@
 source /clone_server.sh
 
+if [[ -v SIMPLE_INDICES ]]; then
+    echo "Replacing database indices for compatibility with DocumentDB"
+    sed -i -e "s|HASHED|ASCENDING|" emission/core/get_database.py
+    sed -i -e "/GEOSPHERE/d" emission/core/get_database.py
+fi
+
 #set database URL using environment variable
 #in the webapp, this is set in start_script
 #but we don't call start_script here since we don't want to start the server

--- a/examples/em-server-multi-tier-cronjob/webapp/start_script.sh
+++ b/examples/em-server-multi-tier-cronjob/webapp/start_script.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
 source /clone_server.sh
+
+if [[ -v SIMPLE_INDICES ]]; then
+    echo "Replacing database indices for compatibility with DocumentDB"
+    sed -i -e "s|HASHED|ASCENDING|" emission/core/get_database.py
+    sed -i -e "/GEOSPHERE/d" emission/core/get_database.py
+fi
+
 source /start_script.sh


### PR DESCRIPTION
DocumentDB is the AWS RDS that is similar to MongoDB. Although it supports most
queries, it has limited support for indices.

To solve this, we introduce a new environment variable SIMPLE_INDICES.
If SIMPLE_INDICES is set, we remove all HASHED and GEOSPHERE indices from the database driver.
We currently do this by editing the file directly, which is a giant hack but works.

If we want to support DocumentDB in the long term, we should move this check to
the source code directly.

This fixes
https://github.com/e-mission/e-mission-docs/issues/597

Testing done:

With this patch to the `docker-compose.yml`

```
diff --git a/examples/em-server-multi-tier-cronjob/docker-compose.yml b/examples/em-server-multi-tier-cronjob/docker-compose.yml
index 75d3f20..9671f61 100644
--- a/examples/em-server-multi-tier-cronjob/docker-compose.yml
+++ b/examples/em-server-multi-tier-cronjob/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - DB_HOST=db
       - WEB_SERVER_HOST=0.0.0.0
       - SERVER_BRANCH=ceo_ebike_project
+      - SIMPLE_INDICES=1
     deploy:
       replicas: 1
       restart_policy:
@@ -27,6 +28,8 @@ services:
       - DB_HOST=db
       - WEB_SERVER_HOST=0.0.0.0
       - SERVER_BRANCH=ceo_ebike_project
+      - SIMPLE_INDICES=1
+
     deploy:
       replicas: 1
       restart_policy:
```

the webserver indices are replaced

```
web-server_1       | Found configuration, overriding...
web-server_1       | Live reload disabled,
web-server_1       | Replacing database indices for compatibility with DocumentDB
```

the analysis indices are replaced

```
analysis-server_1  | Found configuration, overriding...
analysis-server_1  | Live reload disabled,
analysis-server_1  | Replacing database indices for compatibility with DocumentDB
```