### PR TITLE
Change the UI devapp server to use the standard build scripts

### DIFF
--- a/Dockerfile.dev.ui-only
+++ b/Dockerfile.dev.ui-only
@@ -1,52 +1,11 @@
 # python 3
 FROM ubuntu:trusty
 
-ENV NODE_VERSION 9.4.0
-ENV ARCH='x64'
-
 MAINTAINER K. Shankari (shankari@eecs.berkeley.edu)
 
 # setup the correct version of node using nvm
 RUN apt-get -y install curl
 RUN apt-get -y install xz-utils
-# copied from the official nodejs Dockerfile
-RUN set -ex \
-    && for key in \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    77984A986EBC2AA786BC0F66B01FBB92821C587A \
-    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-    4ED778F539E3634C779C87C6D7062848A1AB005C \
-    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
-    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
-  ; do \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-  done \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
-  # smoke tests
-  && node --version \
-  && npm --version
-
-# RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
-# RUN /bin/bash -c "source /root/.nvm/nvm.sh; nvm install 9.4.0"
- 
-# Upgrade the version of npm to the correct one
-RUN npm install -g npm@6.0.0
-
-# Install bower
-RUN npm install -g bower@1.8.4
 
 # Git for checking out code
 RUN apt-get -y install git
@@ -57,6 +16,7 @@ ADD start_devapp_serve.sh /start_devapp_serve.sh
 
 #declare environment variables
 ENV PHONE_REPO='https://github.com/e-mission/e-mission-phone.git'
+ENV PHONE_BRANCH='master'
 EXPOSE 3000
 
 CMD ["/bin/bash", "/start_devapp_serve.sh"]

--- a/examples/em-phone-devapp-serve/README.md
+++ b/examples/em-phone-devapp-serve/README.md
@@ -10,9 +10,11 @@ container, and will be removed when the container is removed.
 
 #### `docker-compose.livereload.yml`: Deploy the container for editing ####
 
-- The code will be mounted to a directory on your host
+- The code will be mounted to a directory on your host. You may need to create this directory if it does not exist.
 - Edit the code on the host for auto-reload
 - Restarting the container will retain changes from previous runs
 - Currently checks out to ~/e-mission-phone-docker/src
 - Change this using the `CHANGEME` locations if needed
 - If you run into issues - commit and push your pending changes, remove the host directory and restart, which will check out the repo and set everything up again
+
+

--- a/start_devapp_serve.sh
+++ b/start_devapp_serve.sh
@@ -11,15 +11,14 @@ cd e-mission-phone
 git clone https://github.com/driftyco/ionic-package-hooks.git ./package-hooks
 git fetch origin $PHONE_BRANCH
 git checkout -f $PHONE_BRANCH
-node ./bin/configure_xml_and_json.js serve
-
-echo "About to install node modules"
-npm install
-
-echo "About to install bower modules"
+# Restore the tail command below to debug image creation
+# tail -f /dev/null
+bash setup/setup_serve.sh
+# Normally, this would happen in the setup, but bower doesn't like running as root
+# and we are root in the container, of course
+# instead of changing that for everybody, we only change it in the container
 bower install --allow-root
-# chmod a+x hooks/before_prepare/download_translation.js
-# npm run sass-build
+source setup/activate_serve.sh
 
 echo "About to fix autoreload script"
 ORIG="path.join(process.cwd(), 'www/../.')"
@@ -31,5 +30,4 @@ grep "path.join" /src/e-mission-phone/node_modules//connect-phonegap/lib/middlew
 # cp /chokidar-index.js /src/e-mission-phone/node_modules/chokidar/index.js
 
 # launch the webapp
-npm run setup-serve
 npm run serve


### PR DESCRIPTION
I originally wanted to put all the dependencies into the image instead of
waiting until the container was set up. But different branches could have
different dependencies and may not want to upgrade/downgrade. And putting this
into the container allows us to use the standard build scripts and not have
this bitrot.

This file had
ENV NODE_VERSION 9.4.0
RUN npm install -g npm@6.0.0

We are currently at

export NODE_VERSION=14.7.0
export NPM_VERSION=6.14.8

using the standard scripts, which are regularly tested via CI, allows us to
ensure that this dockerfile stays relevant across the many configurations that
we currently support.

This fixes https://github.com/e-mission/e-mission-docs/issues/657