### PR TITLE
Remove the duplicate call to bower

### DIFF
--- a/start_devapp_serve.sh
+++ b/start_devapp_serve.sh
@@ -14,10 +14,6 @@ git checkout -f $PHONE_BRANCH
 # Restore the tail command below to debug image creation
 # tail -f /dev/null
 bash setup/setup_serve.sh
-# Normally, this would happen in the setup, but bower doesn't like running as root
-# and we are root in the container, of course
-# instead of changing that for everybody, we only change it in the container
-bower install --allow-root
 source setup/activate_serve.sh
 
 echo "About to fix autoreload script"


### PR DESCRIPTION
Duplicating the command led to multiple inconsistencies (
    https://github.com/e-mission/e-mission-docs/issues/657#issuecomment-894981839
    https://github.com/e-mission/e-mission-docs/issues/657#issuecomment-894994308
)

So I changed the code in the phone repo instead (https://github.com/e-mission/e-mission-phone/pull/776)
and switched to using only the setup scripts here.