### PR TITLE
test image CI

### DIFF
--- a/examples/em-server-multi-tier-cronjob/analysis/Dockerfile
+++ b/examples/em-server-multi-tier-cronjob/analysis/Dockerfile
@@ -6,7 +6,7 @@ COPY conf /conf
 # CHANGEME: Default crontab runs the regular intake pipeline every hour at 5
 # mins past the hour. Also includes some additional commented out scripts.
 # Replace by your own if you need any other periodic invocations
-COPY crontab /usr/src/app/crontab
-COPY start_cron.sh /usr/src/app/start_cron.sh
+COPY crontab /usr/src/app/.docker/crontab
+COPY start_cron.sh /usr/src/app/.docker/start_cron.sh
 
-CMD ["/bin/bash", "/usr/src/app/start_cron.sh"]
+CMD ["/bin/bash", "/usr/src/app/.docker/start_cron.sh"]

--- a/examples/em-server-multi-tier-cronjob/analysis/Dockerfile
+++ b/examples/em-server-multi-tier-cronjob/analysis/Dockerfile
@@ -1,5 +1,5 @@
 # python 3
-FROM emission/e-mission-server.dev.server-only:4.0.0
+FROM agutt/e-mission-server:ceo_ebike_project_2022-09-19--45-23
 
 COPY conf /conf
 

--- a/examples/em-server-multi-tier-cronjob/analysis/Dockerfile
+++ b/examples/em-server-multi-tier-cronjob/analysis/Dockerfile
@@ -1,5 +1,5 @@
 # python 3
-FROM agutt/e-mission-server:ceo_ebike_project_2022-09-19--45-23
+FROM shankari/e-mission-server:master_2022-09-22--20-37
 
 COPY conf /conf
 

--- a/examples/em-server-multi-tier-cronjob/analysis/start_cron.sh
+++ b/examples/em-server-multi-tier-cronjob/analysis/start_cron.sh
@@ -1,4 +1,4 @@
-source /clone_server.sh
+source ./.docker/setup_config.sh
 
 if [[ -v SIMPLE_INDICES ]]; then
     echo "Replacing database indices for compatibility with DocumentDB"
@@ -29,4 +29,4 @@ pip install devcron
 # launch the cronjob
 echo "Launch the cronjob"
 # while true; do sleep 30; done;
-devcron ../crontab >> /var/log/cron.console.stdinout 2>&1
+devcron ./crontab >> /var/log/cron.console.stdinout 2>&1

--- a/examples/em-server-multi-tier-cronjob/analysis/start_cron.sh
+++ b/examples/em-server-multi-tier-cronjob/analysis/start_cron.sh
@@ -1,4 +1,7 @@
-source ./.docker/setup_config.sh
+if [ -d "/conf" ]; then
+    echo "Found configuration, overriding..."
+    cp -r /conf/* conf/
+fi
 
 if [[ -v SIMPLE_INDICES ]]; then
     echo "Replacing database indices for compatibility with DocumentDB"
@@ -29,4 +32,4 @@ pip install devcron
 # launch the cronjob
 echo "Launch the cronjob"
 # while true; do sleep 30; done;
-devcron ./crontab >> /var/log/cron.console.stdinout 2>&1
+devcron ./.docker/crontab >> /var/log/cron.console.stdinout 2>&1

--- a/examples/em-server-multi-tier-cronjob/webapp/Dockerfile
+++ b/examples/em-server-multi-tier-cronjob/webapp/Dockerfile
@@ -1,5 +1,5 @@
 # python 3
-FROM emission/e-mission-server.dev.server-only:4.0.0
+FROM agutt/e-mission-server:ceo_ebike_project_2022-09-19--45-23
 
 COPY conf /conf
 

--- a/examples/em-server-multi-tier-cronjob/webapp/Dockerfile
+++ b/examples/em-server-multi-tier-cronjob/webapp/Dockerfile
@@ -3,5 +3,5 @@ FROM agutt/e-mission-server:ceo_ebike_project_2022-09-19--45-23
 
 COPY conf /conf
 
-COPY start_script.sh /usr/src/app/start_script.sh
-CMD ["/bin/bash", "/usr/src/app/start_script.sh"]
+COPY start_script.sh /usr/src/app/.docker/start_script.sh
+CMD ["/bin/bash", "/usr/src/app/.docker/start_script.sh"]

--- a/examples/em-server-multi-tier-cronjob/webapp/Dockerfile
+++ b/examples/em-server-multi-tier-cronjob/webapp/Dockerfile
@@ -1,5 +1,5 @@
 # python 3
-FROM agutt/e-mission-server:ceo_ebike_project_2022-09-19--45-23
+FROM shankari/e-mission-server:master_2022-09-22--20-37
 
 COPY conf /conf
 

--- a/examples/em-server-multi-tier-cronjob/webapp/start_script.sh
+++ b/examples/em-server-multi-tier-cronjob/webapp/start_script.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source /clone_server.sh
+
+source ./.docker/setup_config.sh
 
 if [[ -v SIMPLE_INDICES ]]; then
     echo "Replacing database indices for compatibility with DocumentDB"
@@ -7,4 +8,4 @@ if [[ -v SIMPLE_INDICES ]]; then
     sed -i -e "/GEOSPHERE/d" emission/core/get_database.py
 fi
 
-source /start_script.sh
+source ./.docker/docker_start_script.sh

--- a/examples/em-server-multi-tier-cronjob/webapp/start_script.sh
+++ b/examples/em-server-multi-tier-cronjob/webapp/start_script.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-source ./.docker/setup_config.sh
+if [ -d "/conf" ]; then
+    echo "Found configuration, overriding..."
+    cp -r /conf/* conf/
+fi
 
 if [[ -v SIMPLE_INDICES ]]; then
     echo "Replacing database indices for compatibility with DocumentDB"


### PR DESCRIPTION
Changes made within `examples/em-server-multi-tier-cronjob` to use and run server images created by new CI in `e-mission-server`.

`CHANGEME` left in `docker-compose.yml` for port number so that user/tester can think about what they need for their purposes themselves.

Results of testing shown in https://github.com/e-mission/e-mission-server/pull/875.

Requisite task to show feature https://github.com/e-mission/e-mission-docs/issues/752 working.