### PR TITLE
Use Args in Compose to set Image

### DIFF
--- a/examples/em-server-multi-tier-cronjob/analysis/Dockerfile
+++ b/examples/em-server-multi-tier-cronjob/analysis/Dockerfile
@@ -1,5 +1,7 @@
 # python 3
-FROM shankari/e-mission-server:master_2022-09-22--20-37
+ARG SERVER_IMAGE_TAG=master_2022-10-09--26-05
+
+FROM shankari/e-mission-server:${SERVER_IMAGE_TAG}
 
 COPY conf /conf
 

--- a/examples/em-server-multi-tier-cronjob/docker-compose.yml
+++ b/examples/em-server-multi-tier-cronjob/docker-compose.yml
@@ -1,7 +1,10 @@
 version: "3"
 services:
   web-server:
-    build: webapp
+    build:
+      context: ./webapp
+      args:
+        SERVER_IMAGE_TAG: master_2022-10-09--26-05
     depends_on:
       - db
     environment:
@@ -20,7 +23,10 @@ services:
     networks:
       - emission
   analysis-server:
-    build: analysis
+    build:
+      context: ./analysis
+      args:
+        SERVER_IMAGE_TAG: master_2022-10-09--26-05
     depends_on:
       - db
     environment:

--- a/examples/em-server-multi-tier-cronjob/webapp/Dockerfile
+++ b/examples/em-server-multi-tier-cronjob/webapp/Dockerfile
@@ -1,5 +1,7 @@
 # python 3
-FROM shankari/e-mission-server:master_2022-09-22--20-37
+ARG SERVER_IMAGE_TAG=master_2022-10-09--26-05
+
+FROM shankari/e-mission-server:${SERVER_IMAGE_TAG}
 
 COPY conf /conf
 


### PR DESCRIPTION
Adds args SERVER_IMAGE_TAG to webapp and analysis in the docker-compose. ARGs used in Dockerfiles of webapp and analysis to set server image to pull.

Tested. All containers run without problems. Redirects to NREL OpenPATH webpage as intended when connected to.